### PR TITLE
Fix for actuation in state transitions

### DIFF
--- a/src/fsa.py
+++ b/src/fsa.py
@@ -101,7 +101,7 @@ class Automaton:
         proposition values associated with the given state
         """
 
-        for key, output_val in self.current_state.outputs.iteritems():
+        for key, output_val in state.outputs.iteritems():
             # Skip any "bitX" region encodings
             if re.match('^bit\d+$', key): continue 
 


### PR DESCRIPTION
As I e-mailed, I believe this commit fixes a bug in updateOutputs. The result of this bug was that actuations were performed for the current state rather than for the next state, unlike motions which were performed for the next state. The fix just changes updateOutputs to operate on its argument rather than the current state in self.
