### PR TITLE
[Johnny5] Removed suffix -fixed from vicon pose model in .robot file.

### DIFF
--- a/src/lib/handlers/Johnny5/Johnny5.robot
+++ b/src/lib/handlers/Johnny5/Johnny5.robot
@@ -17,7 +17,7 @@ MotionControlHandler: # Robot default motion control handler with default argume
 share.MotionControl.VectorControllerHandler()
 
 PoseHandler: # Robot default pose handler with default argument values
-share.Pose.ViconPoseHandler(host="10.0.0.102",port=800,x_VICON_name="Johnny5-fixed:Johnny5 <t-X>",y_VICON_name="Johnny5-fixed:Johnny5 <t-Y>",theta_VICON_name="Johnny5-fixed:Johnny5 <a-Z>")
+share.Pose.ViconPoseHandler(host="10.0.0.102",port=800,x_VICON_name="Johnny5:Johnny5 <t-X>",y_VICON_name="Johnny5:Johnny5 <t-Y>",theta_VICON_name="Johnny5:Johnny5 <a-Z>")
 
 SensorHandler: # Robot default sensor handler with default argument values
 Johnny5.Johnny5SensorHandler()


### PR DESCRIPTION
When setting up the Demo Station, we spotted a discrepancy between the Vicon model name on Nexus and the Vicon model name in <code>Johnny5.robot</code> Not sure where that <code>fixed</code> came from.
